### PR TITLE
Generate Windows build with GitHub actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,3 +38,34 @@ jobs:
         with:
           name: Build
           path: build
+
+  nightly:
+    name: Publish the latest Build
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: Build
+          path: ./
+      - name: Zip windows build
+        run: |
+          zip -r StandaloneWindows64.zip StandaloneWindows64
+      - name: List files
+        run: ls -rl
+      - name: Update nightly release
+        uses: andelf/nightly-release@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_GH_TOKEN }}
+        with:
+          tag_name: nightly
+          name: 'Latest build from the main branch $$'
+          draft: false
+          prerelease: true
+          body: |
+            This is the latest build from the main branch.
+            It is not an official release. *Use with caution!*
+          files:
+            ./*.zip

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,40 @@
+name: Actions 😎
+
+on: push
+
+jobs:
+  build:
+    name: Build my project ✨
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout repository ⬇️
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      # Cache
+      - uses: actions/cache@v3
+        with:
+          path: Library
+          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-
+
+      # Build
+      - name: Build project 🔨
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: StandaloneWindows64
+
+      # Output
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Build
+          path: build


### PR DESCRIPTION
A GitHub action workflow generates the Windows build using the Unity educational license from USC. The artefact is available for each action run on the GitHub action page. When a PR is merged, the action runs once again, but this time updates the "nighty" tag and attaches the artefact to the nightly release: https://github.com/IRL2/narupa-imd/releases/tag/nightly