### PR TITLE
Avoid running the workflow on tags

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,11 @@
 name: Actions 😎
 
-on: push
+on:
+  push:
+    # `on: push` triggers on pushes to both branches and tags,
+    # We do not want to trigger this workflow on tags, especially not on the 'nightly' tag.
+    branches:
+      - "**"
 
 jobs:
   build:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -80,6 +80,7 @@ jobs:
     name: Build the conda Packages
     runs-on: windows-latest
     needs: [build]
+    if: github.ref == 'refs/heads/master'
     steps:
       # We need to download the source code to get the version number
       # since we define it from the number of commits.


### PR DESCRIPTION
The CI workflow runs on pushes to both branches and tags. Pushes to master trigger the workflow, which updates the 'nightly' tag, which triggers a useless workflow.

This commit prevents the triggering of the workflow on tags.

Fixes #9 

The PR also stops the building of the conda package on PR because it is very slow. The conda package is only built on pushes to master.