### PR TITLE
Copy the SteamVrControllerDefinitionTests from the plugin

### DIFF
--- a/Assets/NarupaIMD/Tests/NarupaIMD.Tests.asmdef
+++ b/Assets/NarupaIMD/Tests/NarupaIMD.Tests.asmdef
@@ -4,6 +4,7 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "Narupa.Core",
+        "Narupa.Frontend",
         "NarupaImd"
     ],
     "includePlatforms": [

--- a/Assets/NarupaIMD/Tests/SteamVrControllerDefinitionTests.cs
+++ b/Assets/NarupaIMD/Tests/SteamVrControllerDefinitionTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Intangible Realities Lab. All rights reserved.
+// Licensed under the GPL. See License.txt in the project root for license information.
+
+using Narupa.Frontend.Controllers;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace NarupaIMD.Tests
+{
+    public class SteamVrControllerDefinitionTests
+    {
+        [Test]
+        public void SupportsOculus()
+        {
+            Assert.IsNotNull(SteamVrControllerDefinition.GetControllerDefinition("oculus_touch"));
+        }
+        
+        [Test]
+        public void SupportsIndex()
+        {
+            Assert.IsNotNull(SteamVrControllerDefinition.GetControllerDefinition("knuckles"));
+        }
+        
+        [Test]
+        public void SupportsVive()
+        {
+            Assert.IsNotNull(SteamVrControllerDefinition.GetControllerDefinition("vive_controller"));
+        }
+    }
+}


### PR DESCRIPTION
The plugin defines a series of test to assert that the host project has the required assets to support some predefined controllers (Index, Oculus, Vive, and Fallback). This test, by its very nature, depends on files from the host project, meaning it will necesseraly fail when run against the plugin itself.

Here, we copy the test in the NarupaIMD project so it can run here, where all the required files are, rather than in the plugin. Ultimately, it is the responsibility of the host to choose what controllers it want to support.