### PR TITLE
Fix job dependencies in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -147,7 +147,7 @@ jobs:
   conda:
     name: Build the conda Packages
     runs-on: windows-latest
-    needs: [build, tests]
+    needs: [artefact-build, tests]
     if: github.ref == 'refs/heads/master'
     steps:
       # We need to download the source code to get the version number


### PR DESCRIPTION
The job that builds the conda package was depending on the job that generates
 the windows build without saving it. This lead to the conda package not being built
since the job it depended from is not running for the master branch.