### PR TITLE
Try another token option for publishing the nightly release

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -128,6 +128,8 @@ jobs:
         run: ls -rl
       - name: Update nightly release
         uses: andelf/nightly-release@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: nightly
           name: 'Latest build from the main branch $$'


### PR DESCRIPTION
Without token, publishing the nightly release does not work, This commit tries another approach.