### PR TITLE
Update some guthub actions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: true
           ref: ${{ steps.comment-branch.outputs.head_ref }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: Library
           key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
@@ -37,7 +37,7 @@ jobs:
           targetPlatform: StandaloneWindows64
           buildName: 'NanoVer iMD'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: true
 
       # Cache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: Library
           key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
@@ -52,7 +52,7 @@ jobs:
           submodules: true
 
       # Cache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: Library
           key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
@@ -71,7 +71,7 @@ jobs:
           buildName: 'NanoVer iMD'
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -88,7 +88,7 @@ jobs:
           submodules: true
 
       # Cache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: Library
           key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
@@ -104,7 +104,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Upload test results 📖
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.run_tests.outcome == 'failure'
         with:
           name: Test results
@@ -186,7 +186,7 @@ jobs:
           echo "build_number: $env:build_number"
           echo "frontend_version: $env:frontend_version"
           conda build --numpy 1.11 --no-anaconda-upload --no-test .\conda
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: conda-bld
           path: C:\Miniconda3\envs\test\conda-bld


### PR DESCRIPTION
Github updated the version of node used in actions to version 20. This requires some actions to be updated. This should reduce the number of warnings.